### PR TITLE
Bloc fonctionnalités : migration du layout liste

### DIFF
--- a/assets/sass/cids-theme/styles/blocks.sass
+++ b/assets/sass/cids-theme/styles/blocks.sass
@@ -659,6 +659,7 @@ body:not(.page__home)
                         .feature-description
                             margin-left: 0
                             margin-top: $spacing-1
+                            width: 100%
                 
                 &:has(figure)
                     .feature-content > *

--- a/assets/sass/cids-theme/styles/blocks.sass
+++ b/assets/sass/cids-theme/styles/blocks.sass
@@ -408,8 +408,7 @@ body:not(.page__home)
         .testimonials
             padding-bottom: $spacing-4
             padding-top: $spacing-5
-            @include media-breakpoint-up(desktop)
-                margin-top: -($spacing-5)
+    
     .testimonial
         @include in-page-with-or-without-sidebar
             padding-left: 0
@@ -645,7 +644,6 @@ body:not(.page__home)
                 + .feature
                     margin-top: $spacing-5
                     padding-top: 0
-            
             @include media-breakpoint-down(desktop)
                 .feature
                     figure 
@@ -656,14 +654,17 @@ body:not(.page__home)
             @include in-page-with-or-without-sidebar
                 .feature
                     gap: var(--grid-gutter)
-                    &:has(figure)
-                        .feature-content > *
-                            width: columns(4)
-                    &:has(.is-png, .is-svg)
-                        figure
-                            width: columns(1)
-                        .feature-content > *
-                            width: columns(5)
+                    .feature-content
+                        display: block
+                        .feature-description
+                            margin-left: 0
+                            margin-top: $spacing-1
+                
+                &:has(figure)
+                    .feature-content > *
+                        width: columns(5)
+                    figure.media--icon
+                        width: columns(1)
 
 // datatable
 .block-datatable

--- a/assets/sass/cids-theme/styles/blocks.sass
+++ b/assets/sass/cids-theme/styles/blocks.sass
@@ -104,6 +104,10 @@ body:not(.page__home)
                         color: var(--btn-hover-color)
                 .media
                     margin-bottom: 0
+
+            @include media-breakpoint-down(desktop)
+                > li + li
+                    margin-top: $spacing-5
     
     &--list
         &.with-description
@@ -629,13 +633,37 @@ body:not(.page__home)
 
 // features
 .block-features
-    @include in-page-with-or-without-sidebar
-        ul
-            li
-                gap: var(--grid-gutter)
-                figure
-                    margin-right: 0
-                    order: -1
+    &--grid
+        @include in-page-with-sidebar
+            .features
+                @include grid(1, desktop)
+    &--list
+        .features
+            > .feature
+                border-bottom: 0
+                padding-bottom: 0
+                + .feature
+                    margin-top: $spacing-5
+                    padding-top: 0
+            
+            @include media-breakpoint-down(desktop)
+                .feature
+                    figure 
+                        picture 
+                            img
+                                width: 100%
+
+            @include in-page-with-or-without-sidebar
+                .feature
+                    gap: var(--grid-gutter)
+                    &:has(figure)
+                        .feature-content > *
+                            width: columns(4)
+                    &:has(.is-png, .is-svg)
+                        figure
+                            width: columns(1)
+                        .feature-content > *
+                            width: columns(5)
 
 // datatable
 .block-datatable


### PR DESCRIPTION
# Migration

Appliquer le layout liste sur https://mids.ch/academics/programme-overview/

----

## Layout grille

Inchangé en pleine largeur : 
<img width="1379" height="863" alt="Capture d’écran 2026-04-29 à 16 14 15" src="https://github.com/user-attachments/assets/68fa9daf-cd14-48c6-8a1b-028357d5ca1c" />

Grille de 1 en semi largeur : 
<img width="1376" height="628" alt="Capture d’écran 2026-04-29 à 16 14 44" src="https://github.com/user-attachments/assets/0f9d69fd-ef91-41b8-916a-b625efad5d44" />

## Layout liste
Avec image : 
<img width="1381" height="718" alt="Capture d’écran 2026-04-29 à 16 12 15" src="https://github.com/user-attachments/assets/2c20ce1f-9103-4cc5-8559-e0b29a222d38" />

Sans image : 
<img width="1376" height="956" alt="Capture d’écran 2026-04-29 à 16 13 57" src="https://github.com/user-attachments/assets/68a8f16b-1698-4182-82a2-f627ab04284f" />

----

mobile OK
icones OK